### PR TITLE
Update deps to fix error

### DIFF
--- a/Tutorials/p0-output/Cargo.toml
+++ b/Tutorials/p0-output/Cargo.toml
@@ -9,15 +9,15 @@ resolver = "2"
 opt-level = "s"
 
 [profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
+debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
 pio = ["esp-idf-sys/pio"]
 
 [dependencies]
-esp-idf-sys = { version = "0.32", features = ["binstart"] }
-esp-idf-hal = "0.40"
+esp-idf-sys = { version = "0.33.7", features = ["binstart"] }
+esp-idf-hal = "0.42.5"
 esp-println = { version = "0.3.1", features = ["esp32c3"] }
 
 [build-dependencies]


### PR DESCRIPTION
I tried building and running the `Tutorials/p0-output` folder. I got this error:
```
error[E0432]: unresolved import `core::sync::atomic::AtomicU64`
 --> /var/home/rajas/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-hal-0.40.1/src/interrupt.rs:1:26
  |
1 | use core::sync::atomic::{AtomicU64, Ordering};
  |                          ^^^^^^^^^
  |                          |
  |                          no `AtomicU64` in `sync::atomic`
  |                          help: a similar name exists in the module: `AtomicU32`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `esp-idf-hal` (lib) due to 1 previous error
```
After updating the dependencies I no longer get that error and I was able to flash the blinky program successfully.