### PR TITLE
Update build command to use `espflash flash` instead of just `espflash`

### DIFF
--- a/Tutorials/p0-output/.cargo/config.toml
+++ b/Tutorials/p0-output/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p1-input/.cargo/config.toml
+++ b/Tutorials/p1-input/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p2-threads/.cargo/config.toml
+++ b/Tutorials/p2-threads/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p3-adc/.cargo/config.toml
+++ b/Tutorials/p3-adc/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p4-dht11/.cargo/config.toml
+++ b/Tutorials/p4-dht11/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p5-i2c/.cargo/config.toml
+++ b/Tutorials/p5-i2c/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p6-spi/.cargo/config.toml
+++ b/Tutorials/p6-spi/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p7-uart/.cargo/config.toml
+++ b/Tutorials/p7-uart/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/Tutorials/p8-cli/.cargo/config.toml
+++ b/Tutorials/p8-cli/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch03-blinky-fsm/.cargo/config.toml
+++ b/WIP/ch03-blinky-fsm/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch04-blinky-button-hsm/.cargo/config.toml
+++ b/WIP/ch04-blinky-button-hsm/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch04-blinky-multi-thread/.cargo/config.toml
+++ b/WIP/ch04-blinky-multi-thread/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch05-adc_to_ledc/.cargo/config.toml
+++ b/WIP/ch05-adc_to_ledc/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch05-blinky-crossbeams/.cargo/config.toml
+++ b/WIP/ch05-blinky-crossbeams/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch06-blinky-adc/.cargo/config.toml
+++ b/WIP/ch06-blinky-adc/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch06-neopixel/.cargo/config.toml
+++ b/WIP/ch06-neopixel/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch06-wifi-mqtt/.cargo/config.toml
+++ b/WIP/ch06-wifi-mqtt/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/ch07-blinky-mqtt/.cargo/config.toml
+++ b/WIP/ch07-blinky-mqtt/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/p4-neopixel/.cargo/config.toml
+++ b/WIP/p4-neopixel/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]

--- a/WIP/wifi/.cargo/config.toml
+++ b/WIP/wifi/.cargo/config.toml
@@ -7,22 +7,22 @@ target = "riscv32imc-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 #rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
 # For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
 rustflags = ["-C", "default-linker-libraries"]


### PR DESCRIPTION
Without this change I get this error:
```
   Compiling input v0.1.0 (/var/home/rajas/Documents/ESP32-C3_Rust_Tutorials/Tutorials/p0-output)
    Finished dev [optimized + debuginfo] target(s) in 0.87s
     Running `espflash --monitor target/riscv32imc-esp-espidf/debug/input`
error: unexpected argument '--monitor' found

Usage: espflash <COMMAND>

For more information, try '--help'.
```

Seems like `espflash` v2 changed its CLI
More information:
https://github.com/esp-rs/esp-idf-template/blob/f83d638cec6eee8b00de86ad88350f5ec7ce3186/cargo/.cargo/config.toml#L6-L7