### PR TITLE
Rename crate to `output` for `p0-output`

### DIFF
--- a/Tutorials/p0-output/Cargo.toml
+++ b/Tutorials/p0-output/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "input"
+name = "output"
 version = "0.1.0"
 authors = ["Shane"]
 edition = "2021"

--- a/Tutorials/p0-output/src/main.rs
+++ b/Tutorials/p0-output/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
     esp_idf_sys::link_patches();
 
-    println!("Starting 0-input\nThis application is a basic blinky program that turns an LED on and off every 1 second.\n");
+    println!("Starting 0-output\nThis application is a basic blinky program that turns an LED on and off every 1 second.\n");
 
     // Get all the peripherals
     let peripherals = Peripherals::take().unwrap();


### PR DESCRIPTION
I'm guessing it's meant to be called `output` cuz that's the folder name and an LED is an output.